### PR TITLE
[FIX] 🐛 WebSocket 연결 오류 수정

### DIFF
--- a/.platform/nginx.conf
+++ b/.platform/nginx.conf
@@ -59,6 +59,8 @@ http {
           proxy_set_header      Host            $host;
           proxy_set_header      X-Real-IP       $remote_addr;
           proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+
+          proxy_set_header      Origin          "";
       }
 
       access_log    /var/log/nginx/access.log main;


### PR DESCRIPTION
- /call 경로의 proxy_set_header 설정에 Origin 헤더 추가
- 기존에는 Origin 헤더가 설정되지 않아 CORS 정책에 의해 요청이 거부 되었다
- Origin 헤더를 빈 문자열로 설정하여 CORS 관련 문제 해결