### PR TITLE
fix(nginx.conf): 웹소켓을 위한 nginx proxy_read_timeout 을 300초로 설정

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -61,6 +61,8 @@ http {
           proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
 
           proxy_set_header      Origin          "";
+
+          proxy_read_timeout 300;
       }
 
       access_log    /var/log/nginx/access.log main;


### PR DESCRIPTION
- kurento ping/pong keep alive 는 240초 간격으로 작동한다
- nginx proxy_read_timeout 은 기본 60초이다.
- 따라서 nginx proxy_read_timeout 의 값을 300초로 늘렸다.