### PR TITLE
[FEAT] 캘린더 색상 객체 및 색상 변경 api 작성

### DIFF
--- a/src/main/java/Growup/spring/calender/controller/CalenderController.java
+++ b/src/main/java/Growup/spring/calender/controller/CalenderController.java
@@ -66,15 +66,16 @@ public class CalenderController {
         return ApiResponse.onSuccessWithoutResult(SuccessStatus._OK);
     }
 
-/*
+
     //목록 색깔 수정
     @PatchMapping("color-modify")
-    public ApiResponse<SuccessStatus> calenderColorModify(@RequestParam Long calenderId){
-         calenderService.calenderColorModify(calenderId);
+    public ApiResponse<SuccessStatus> calenderColorModify(@RequestBody @Valid CalenderDtoReq.calenderColorModify request){
+        Long userId = jwtProvider.getUserID();
+         calenderService.calenderColorModify(userId,request);
          return ApiResponse.onSuccessWithoutResult(SuccessStatus._OK);
     }
 
- */
+
 
     //목록 삭제
     @DeleteMapping("/delete")

--- a/src/main/java/Growup/spring/calender/converter/CalenderConverter.java
+++ b/src/main/java/Growup/spring/calender/converter/CalenderConverter.java
@@ -3,6 +3,8 @@ package Growup.spring.calender.converter;
 import Growup.spring.calender.dto.CalenderDtoReq;
 import Growup.spring.calender.dto.CalenderDtoRes;
 import Growup.spring.calender.model.Calender;
+import Growup.spring.calender.model.CalenderColor;
+import Growup.spring.calender.model.Enum.CalenderColorStatus;
 import Growup.spring.user.model.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,19 +48,21 @@ public class CalenderConverter {
     }
 
     //캘린더 특정 날짜 조회 응답
-    public static CalenderDtoRes.calenderInquiryResultRes calenderInquiryResultRes(Long userId, LocalDate day, List<CalenderDtoRes.calenderInquiryRes> calenderInquiryRes){
+    public static CalenderDtoRes.calenderInquiryResultRes calenderInquiryResultRes(Long userId, LocalDate day, CalenderColorStatus color, List<CalenderDtoRes.calenderInquiryRes> calenderInquiryRes){
         return CalenderDtoRes.calenderInquiryResultRes.builder()
                 .userId(userId)
                 .day(day)
+                .color(color)
                 .calenderInquiryLists(calenderInquiryRes)
                 .build();
     }
 
     //캘린더 특정 달 조회 - 특정 날짜 리스트화+날짜
-    public static CalenderDtoRes.calenderMonthInquiryRes calenderMonthInquiryRes(LocalDate date, Map<LocalDate, List<CalenderDtoRes.calenderInquiryRes>> groupedByDay){
+    public static CalenderDtoRes.calenderMonthInquiryRes calenderMonthInquiryRes(LocalDate date, CalenderColorStatus color, List<CalenderDtoRes.calenderInquiryRes> inquiryResList){
         return CalenderDtoRes.calenderMonthInquiryRes.builder()
                 .day(date)
-                .calenderInquiryLists(groupedByDay.getOrDefault(date, List.of()))
+                .color(color)
+                .calenderInquiryLists(inquiryResList)
                 .build();
     }
 
@@ -67,6 +71,15 @@ public class CalenderConverter {
         return CalenderDtoRes.calenderMonthInquiryResultRes.builder()
                 .userId(userId)
                 .calenderMonthInquiryLists(calenderMonthInquiryResList)
+                .build();
+    }
+
+    //캘린더 날짜 객체 생성
+    public static CalenderColor toCalenderColor(User user,CalenderDtoReq.calenderColorModify request){
+        return CalenderColor.builder()
+                .user(user)
+                .day(request.getDay())
+                .color(request.getColor())
                 .build();
     }
 

--- a/src/main/java/Growup/spring/calender/dto/CalenderDtoReq.java
+++ b/src/main/java/Growup/spring/calender/dto/CalenderDtoReq.java
@@ -1,11 +1,11 @@
 package Growup.spring.calender.dto;
 
+import Growup.spring.calender.model.Enum.CalenderColorStatus;
 import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.util.List;
 
 public class CalenderDtoReq {
 
@@ -23,6 +23,14 @@ public class CalenderDtoReq {
         private Long calenderId;
         @NotBlank
         private String comment;
+    }
+
+    @Getter
+    public static class calenderColorModify{
+        @NotNull
+        private LocalDate day;
+        @NotNull
+        private CalenderColorStatus color;
     }
 
 

--- a/src/main/java/Growup/spring/calender/dto/CalenderDtoRes.java
+++ b/src/main/java/Growup/spring/calender/dto/CalenderDtoRes.java
@@ -1,6 +1,6 @@
 package Growup.spring.calender.dto;
 
-import Growup.spring.calender.model.Enum.CalenderColor;
+import Growup.spring.calender.model.Enum.CalenderColorStatus;
 import Growup.spring.calender.model.Enum.CalenderStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,6 +32,7 @@ public class CalenderDtoRes {
     public static class calenderInquiryResultRes{
         private Long userId;
         private LocalDate day;
+        private CalenderColorStatus color;
         private List<calenderInquiryRes> calenderInquiryLists;
     }
 
@@ -54,6 +55,7 @@ public class CalenderDtoRes {
     @AllArgsConstructor
     public static class calenderMonthInquiryRes{
         private LocalDate day;
+        private CalenderColorStatus color;
         private List<calenderInquiryRes> calenderInquiryLists;
     }
 

--- a/src/main/java/Growup/spring/calender/model/CalenderColor.java
+++ b/src/main/java/Growup/spring/calender/model/CalenderColor.java
@@ -1,11 +1,12 @@
 package Growup.spring.calender.model;
 
-import Growup.spring.calender.model.Enum.CalenderStatus;
+import Growup.spring.calender.model.Enum.CalenderColorStatus;
 import Growup.spring.constant.entity.BaseEntity;
 import Growup.spring.user.model.User;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -18,19 +19,16 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Calender extends BaseEntity {
+public class CalenderColor extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
-
-    private String comment;
+    private Long id;
 
     private LocalDate day;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(10) DEFAULT 'ACTIVE'")
-    private CalenderStatus status;
+    private CalenderColorStatus color;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="userId")

--- a/src/main/java/Growup/spring/calender/model/Enum/CalenderColorStatus.java
+++ b/src/main/java/Growup/spring/calender/model/Enum/CalenderColorStatus.java
@@ -1,5 +1,5 @@
 package Growup.spring.calender.model.Enum;
 
-public enum CalenderColor {
+public enum CalenderColorStatus {
     WHITE,RED,PURPLE,YELLOW
 }

--- a/src/main/java/Growup/spring/calender/repository/CalenderColorRepository.java
+++ b/src/main/java/Growup/spring/calender/repository/CalenderColorRepository.java
@@ -1,0 +1,19 @@
+package Growup.spring.calender.repository;
+
+import Growup.spring.calender.model.Calender;
+import Growup.spring.calender.model.CalenderColor;
+import Growup.spring.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface CalenderColorRepository extends JpaRepository<CalenderColor,Long> {
+
+    CalenderColor findByUserAndDay(User user, LocalDate day);
+
+    List<CalenderColor> findByUserAndDayBetween(User user,LocalDate startOfMonth,LocalDate endOfMonth);
+
+}

--- a/src/main/java/Growup/spring/calender/repository/CalenderRepository.java
+++ b/src/main/java/Growup/spring/calender/repository/CalenderRepository.java
@@ -15,5 +15,4 @@ public interface CalenderRepository extends JpaRepository<Calender,Long> {
     Optional<Calender> findById(Long CalenderId);
 
 
-
 }

--- a/src/main/java/Growup/spring/calender/service/CalenderService.java
+++ b/src/main/java/Growup/spring/calender/service/CalenderService.java
@@ -19,4 +19,6 @@ public interface CalenderService {
     void calenderStatusModify(Long calenderId);
 
     void calenderDelete(Long calenderId);
+
+    void calenderColorModify(Long userId,CalenderDtoReq.calenderColorModify request);
 }

--- a/src/main/java/Growup/spring/user/model/User.java
+++ b/src/main/java/Growup/spring/user/model/User.java
@@ -3,7 +3,7 @@ package Growup.spring.user.model;
 
 
 import Growup.spring.calender.model.Calender;
-import Growup.spring.domain.*;
+import Growup.spring.calender.model.CalenderColor;
 import Growup.spring.growRoom.model.GrowRoom;
 import Growup.spring.liked.model.Liked;
 import Growup.spring.participate.model.Participate;
@@ -77,7 +77,10 @@ public class User extends BaseEntity {
     private List<TodoList> todoLists = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<Calender> Calender = new ArrayList<>();
+    private List<Calender> calenderList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<CalenderColor> calenderColorList = new ArrayList<>();
 
 
     @PreUpdate


### PR DESCRIPTION
캘린더 색상 객체, 색상 기본 설정을 white로 설정.
캘린더 색상 변경 api작성 - 기본값은 white이며, white에서 다른 색상으로 변경시 객체 생성. 다른 색상에서 white로 변경시 해당 객체 delete 하도록하여, 불필요한 데이터들을 삭제시키도록 함.